### PR TITLE
Refactor/allow sitewise keys

### DIFF
--- a/exposq.go
+++ b/exposq.go
@@ -3,8 +3,8 @@ package main
 import (
 	"net/http"
 
+	"./sshttp"
 	"github.com/emirozer/exposq/Godeps/_workspace/src/github.com/codegangsta/negroni"
-	"github.com/emirozer/exposq/sshttp"
 )
 
 func main() {


### PR DESCRIPTION
- Allow targets to define there own keys (use global if not definted)
- use standard lib json encoding

target.json example

```
{
    targets: [
        {
            "user": user,
            "ip": ip,
            "key": "key file",
        },
        {
            "user": user,
            "ip": ip
        }
    ],
    "key": "global key file"
}
```
